### PR TITLE
Add launch file for skeleton tracker

### DIFF
--- a/launch/skeleton_tracker.launch
+++ b/launch/skeleton_tracker.launch
@@ -1,0 +1,6 @@
+<launch>
+    <node name="skel_tracker" output="screen" pkg="openni2_tracker" type="tracker" >
+        <param name="tf_prefix" value="skel" />
+        <param name="relative_frame" value="/head/skel_depth_frame" />
+    </node>
+</launch>

--- a/launch/skeleton_tracker.launch
+++ b/launch/skeleton_tracker.launch
@@ -2,5 +2,6 @@
     <node name="skel_tracker" output="screen" pkg="openni2_tracker" type="tracker" >
         <param name="tf_prefix" value="skel" />
         <param name="relative_frame" value="/head/skel_depth_frame" />
+        <!-- relative_frame must be same name as link in herb's URDF -->
     </node>
 </launch>

--- a/launch/skeleton_tracker.launch
+++ b/launch/skeleton_tracker.launch
@@ -1,7 +1,7 @@
 <launch>
     <node name="skel_tracker" output="screen" pkg="openni2_tracker" type="tracker" >
         <param name="tf_prefix" value="skel" />
-        <param name="relative_frame" value="/head/skel_depth_frame" />
+        <param name="relative_frame" value="head/skel_depth_frame" />
         <!-- relative_frame must be same name as link in herb's URDF -->
     </node>
 </launch>


### PR DESCRIPTION
Not added to startup script because:
1. it only runs on herb2
2. it's an optional (and not lightweight) process
