### PR TITLE
Bugfix/localization - Segway Twist

### DIFF
--- a/config/localization_global.yaml
+++ b/config/localization_global.yaml
@@ -14,9 +14,9 @@ world_frame: map
 odom0: odometry/local
 odom0_config: [
     false, false, false, # x, y, z
-    false, false, false,  # roll, pitch, yaw
-    true,  true, false, # x dot, y dot, z dot
-    false, false, true, # roll dot, pitch dot, yaw dot
+    false, false, false, # roll, pitch, yaw
+    true,  true,  false, # x dot, y dot, z dot
+    false, false, true,  # roll dot, pitch dot, yaw dot
     false, false, false  # x ddot, y ddot, z ddot
 ]
 # Stargazer readings. This specifies a full 6-DOF pose, but will be snapped

--- a/config/localization_global.yaml
+++ b/config/localization_global.yaml
@@ -10,10 +10,7 @@ base_link_frame: herb_base
 # world_frame to the same value as map_frame. The Segway driver is resposnible
 # for publishing the odom to herb_base transform.
 world_frame: map
-# Segway RMP odometry.
-# TODO: Switch to ignoring the Pose component of the message and only
-# integrating twists. This is currently broken because segway_rmp_node does not
-# publish a valid twist covariance matrix.
+# Segway RMP odometry -- twist only.
 odom0: odometry/local
 odom0_config: [
     false, false, false, # x, y, z
@@ -22,19 +19,9 @@ odom0_config: [
     false, false, true, # roll dot, pitch dot, yaw dot
     false, false, false  # x ddot, y ddot, z ddot
 ]
-#odom0: odometry/local
-#odom0_relative: true
-#odom0_config: [
-    #true,  true,  false, # x, y, z
-    #false, false, true,  # roll, pitch, yaw
-    #false, false, false, # x dot, y dot, z dot
-    #false, false, false, # roll dot, pitch dot, yaw dot
-    #false, false, false  # x ddot, y ddot, z ddot
-#]
 # Stargazer readings. This specifies a full 6-DOF pose, but will be snapped
 # into the plane by the "two_d_mode" flag.
 pose0: stargazer/robot_pose
-#pose0_differential: false
 pose0_config: [
     true , true , true , # x, y, z
     true , true , true , # roll, pitch, yaw

--- a/config/localization_global.yaml
+++ b/config/localization_global.yaml
@@ -15,18 +15,26 @@ world_frame: map
 # integrating twists. This is currently broken because segway_rmp_node does not
 # publish a valid twist covariance matrix.
 odom0: odometry/local
-odom0_relative: true
 odom0_config: [
-    true,  true,  false, # x, y, z
-    false, false, true,  # roll, pitch, yaw
-    false, false, false, # x dot, y dot, z dot
-    false, false, false, # roll dot, pitch dot, yaw dot
+    false, false, false, # x, y, z
+    false, false, false,  # roll, pitch, yaw
+    true,  true, false, # x dot, y dot, z dot
+    false, false, true, # roll dot, pitch dot, yaw dot
     false, false, false  # x ddot, y ddot, z ddot
 ]
+#odom0: odometry/local
+#odom0_relative: true
+#odom0_config: [
+    #true,  true,  false, # x, y, z
+    #false, false, true,  # roll, pitch, yaw
+    #false, false, false, # x dot, y dot, z dot
+    #false, false, false, # roll dot, pitch dot, yaw dot
+    #false, false, false  # x ddot, y ddot, z ddot
+#]
 # Stargazer readings. This specifies a full 6-DOF pose, but will be snapped
 # into the plane by the "two_d_mode" flag.
 pose0: stargazer/robot_pose
-pose0_differential: false
+#pose0_differential: false
 pose0_config: [
     true , true , true , # x, y, z
     true , true , true , # roll, pitch, yaw

--- a/config/localization_local.yaml
+++ b/config/localization_local.yaml
@@ -8,8 +8,8 @@ world_frame: odom
 odom0: odom
 odom0_config: [
     false, false, false, # x, y, z
-    false, false, false,  # roll, pitch, yaw
-    true,  true, false, # x dot, y dot, z dot
-    false, false, true, # roll dot, pitch dot, yaw dot
+    false, false, false, # roll, pitch, yaw
+    true,  true,  false, # x dot, y dot, z dot
+    false, false, true,  # roll dot, pitch dot, yaw dot
     false, false, false  # x ddot, y ddot, z ddot
 ]

--- a/config/localization_local.yaml
+++ b/config/localization_local.yaml
@@ -6,11 +6,19 @@ odom_frame: odom
 base_link_frame: herb_base
 world_frame: odom
 odom0: odom
-odom0_relative: true
 odom0_config: [
-    true,  true,  false, # x, y, z
-    false, false, true,  # roll, pitch, yaw
-    false, false, false, # x dot, y dot, z dot
-    false, false, false, # roll dot, pitch dot, yaw dot
+    false, false, false, # x, y, z
+    false, false, false,  # roll, pitch, yaw
+    true,  true, false, # x dot, y dot, z dot
+    false, false, true, # roll dot, pitch dot, yaw dot
     false, false, false  # x ddot, y ddot, z ddot
 ]
+#odom0: odom
+#odom0_relative: true
+#odom0_config: [
+    #true,  true,  false, # x, y, z
+    #false, false, true,  # roll, pitch, yaw
+    #false, false, false, # x dot, y dot, z dot
+    #false, false, false, # roll dot, pitch dot, yaw dot
+    #false, false, false  # x ddot, y ddot, z ddot
+#]

--- a/config/localization_local.yaml
+++ b/config/localization_local.yaml
@@ -13,12 +13,3 @@ odom0_config: [
     false, false, true, # roll dot, pitch dot, yaw dot
     false, false, false  # x ddot, y ddot, z ddot
 ]
-#odom0: odom
-#odom0_relative: true
-#odom0_config: [
-    #true,  true,  false, # x, y, z
-    #false, false, true,  # roll, pitch, yaw
-    #false, false, false, # x dot, y dot, z dot
-    #false, false, false, # roll dot, pitch dot, yaw dot
-    #false, false, false  # x ddot, y ddot, z ddot
-#]


### PR DESCRIPTION
Launch `robot_localization` using Segway's twist data only, not pose. Resolves #7 
