### PR TITLE
Launch Python Joystick Controller

### DIFF
--- a/launch/joystick.launch
+++ b/launch/joystick.launch
@@ -2,6 +2,5 @@
     <machine name="joystick" address="herb0" />
 
     <node machine="joystick" pkg="joy" type="joy_node" name="joy"/>
-    <node machine="joystick" pkg="pr_joy" type="prjoy" name="prjoy"/>
-    <node machine="joystick" pkg="pr_joy" type="joy.py" name="joy_toggle"/>
+    <node machine="joystick" pkg="pr_joy" type="joy.py" name="prjoy"/>
 </launch>

--- a/launch/joystick.launch
+++ b/launch/joystick.launch
@@ -1,6 +1,9 @@
 <launch>
     <machine name="joystick" address="herb0" />
 
-    <node machine="joystick" pkg="joy" type="joy_node" name="joy"/>
+    <node machine="joystick" pkg="joy" type="joy_node" name="joy" output="screen">
+        <!-- republish last command if none received in last 1/5 seconds -->
+        <param name="~autorepeat_rate" value="5" />
+    </node>
     <node machine="joystick" pkg="pr_joy" type="joy.py" name="prjoy"/>
 </launch>


### PR DESCRIPTION
Launch python joystick controller only, and set joy_node's autorepeat to 5hz (necessary to prevent halting while moving Segway)

Requires personalrobotics/pr_joy#2
