### PR TITLE
support multiple hand options when launching statepub

### DIFF
--- a/launch/state_publisher.launch
+++ b/launch/state_publisher.launch
@@ -1,10 +1,32 @@
 <launch>
+  <!-- This extra arg only exists for backwards compatibility before Kinetic
+       where Python expressions are supported -->
+  <arg name="configure_hands" default="false"
+       doc="Boolean flag of whether to use non-default hand options"/>
+  <arg name="left_hand" default="bh280"
+       doc="Which left hand option to use. Options: 'bh280', 'no'"/>
+  <arg name="right_hand" default="bh280"
+       doc="Which right hand option to use. Options: 'bh280', 'no'"/>
+
+  <!-- Load default HERB model -->
+  <group unless="$(arg configure_hands)">
     <param name="robot_description"
            textfile="$(find herb_description)/robots/herb.urdf"/>
     <param name="semantic_robot_description"
            textfile="$(find herb_description)/robots/herb.srdf"/>
+  </group>
 
-    <node pkg="robot_state_publisher" type="robot_state_publisher" name="state_publisher"/>
+  <!-- OR -->
 
-    <node pkg="herb_launch" type="segway_joint_relay.py" name="relay" ns="segway"/>
+  <!-- Load HERB models with custom hand options -->
+  <group if="$(arg configure_hands)">
+    <param name="robot_description"
+           textfile="$(find herb_description)/robots/herb_$(arg left_hand)_left_$(arg right_hand)_right.urdf"/>
+    <param name="semantic_robot_description"
+           textfile="$(find herb_description)/robots/herb_$(arg left_hand)_left_$(arg right_hand)_right.srdf"/>
+  </group>
+
+  <node pkg="robot_state_publisher" type="robot_state_publisher" name="state_publisher"/>
+
+  <node pkg="herb_launch" type="segway_joint_relay.py" name="relay" ns="segway"/>
 </launch>


### PR DESCRIPTION
Supports `state_publisher.launch` loading one of multiple models introduced in https://github.com/personalrobotics/herb_description/pull/29 . Defaults are backwards compatible.
