### PR TITLE
Add RealSense dynamic_reconfigure configuration.

### DIFF
--- a/config/realsense.yaml
+++ b/config/realsense.yaml
@@ -1,0 +1,21 @@
+!!python/object/new:dynamic_reconfigure.encoding.Config
+dictitems:
+  format: png
+  groups: !!python/object/new:dynamic_reconfigure.encoding.Config
+    dictitems:
+      format: png
+      groups: !!python/object/new:dynamic_reconfigure.encoding.Config
+        state: []
+      id: 0
+      jpeg_quality: 80
+      name: Default
+      parameters: !!python/object/new:dynamic_reconfigure.encoding.Config
+        state: []
+      parent: 0
+      png_level: 9
+      state: true
+      type: ''
+    state: []
+  jpeg_quality: 80
+  png_level: 9
+state: []

--- a/launch/realsense.launch
+++ b/launch/realsense.launch
@@ -88,4 +88,6 @@
       <arg name="unite_imu_method"         value="$(arg unite_imu_method)"/>
     </include>
   </group>
+
+  <node name="dynamic_reconfigure_load" pkg="dynamic_reconfigure" type="dynparam" args="load /camera/aligned_depth_to_color/image_raw/compressed $(find herb_launch)/config/realsense.yaml" />
 </launch>


### PR DESCRIPTION
The only change from the default configuration (inherited from `image_transport`) is to use png compression for the aligned depth data. The default is jpg, which isn't able to handle the 16-bit depths provided by the RealSense. There may be a speed penalty (I haven't profiled yet), but OpenCV/libjpeg will just drop the upper 8 bits if it uses jpg, which renders the data unusable for distances farther than 0.25m.

(I don't fully understand why, but the [`cv::imwrite`](https://docs.opencv.org/4.2.0/d4/da8/group__imgcodecs.html#gabbc7ef1aa2edfaa87772f1202d67e0ce) documentation specifically says that 16-bit unsigned images can only be encoded as png/jpeg2000 and not jpeg.)